### PR TITLE
Update rust version to rust:slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.73 as watchexec-builder
+FROM rust:slim as watchexec-builder
 RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo install watchexec-cli
 
 # Sufficient to use scratch here if this is just a holder of the volume. But to


### PR DESCRIPTION
Updates rust version to [`rust:slim`](https://hub.docker.com/layers/library/rust/slim/images/sha256-4d97e2a4297727a5fb59ce5cfebb0bfd06c97311737e473466671c08159d3130?context=explore).

Prevents upstream issue building `plus`.

https://www.notion.so/additive-ai/Local-Redis-Troubleshooting-8302c149d9204b3cb734fd273d0c4273

Tested with:

```
docker compose up --build
```

### Rust Version Error

```
2.561 error: failed to compile `watchexec-cli v1.25.1`, intermediate artifacts can be found at `/tmp/cargo-installv7OaJd`.
2.561 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
2.561 
2.561 Caused by:
2.561   package `clap_complete_nushell v4.5.1` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.73.0
2.561   Try re-running cargo install with `--locked`
------
failed to solve: process "/bin/sh -c CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo install watchexec-cli" did not complete successfully: exit code: 101
```