### PR TITLE
Dockerfile syntax fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim as watchexec-builder
+FROM rust:slim AS watchexec-builder
 RUN CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo install watchexec-cli
 
 # Sufficient to use scratch here if this is just a holder of the volume. But to


### PR DESCRIPTION
This change eliminates the following warning:

 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                                                                                                                                                                                          0.9s